### PR TITLE
haddock parse error

### DIFF
--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -248,7 +248,6 @@ writeHeaders set = do
 -- feeding it all the arguments.
 readCSVFile
     :: (CSV ByteString a)
-    -- ^ A CSV type that can be obtained from ByteString stream
     => CSVSettings
     -- ^ Settings to use in deciphering stream
     -> FilePath


### PR DESCRIPTION
latest Haddock (2.10.0) was saying this:
"""
dist/build/tmp-8337/src/Data/CSV/Conduit.hs:252:5:
    parse error on input `=>'
Installing library in /home/user/.cabal/lib/csv-conduit-0.3/ghc-7.4.1
"""
and the documentation was not installed.  But now it is!
