### PR TITLE
Infix precedence redundancy fix

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -1,5 +1,5 @@
 Name:                csv-conduit
-Version:             0.3.0.2
+Version:             0.3.0.3
 Synopsis:            A flexible, fast, conduit-based CSV parser library for Haskell.
 Homepage:            http://github.com/ozataman/csv-conduit
 License:             BSD3
@@ -9,6 +9,7 @@ Maintainer:          Ozgun Ataman <ozataman@gmail.com>
 Category:            Data, Conduit, CSV, Text
 Build-type:          Simple
 Cabal-version:       >= 1.9.2
+Tested-with:         GHC == 7.6.1
 Description:
   CSV files are the de-facto standard in many situations involving data transfer,
   particularly when dealing with enterprise application or disparate database

--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -118,7 +118,7 @@ instance CSV ByteString (Row ByteString) where
     let
       sep = B.pack [c2w (csvOutputColSep s)]
       wrapField !f = case csvOutputQuoteChar s of
-        Just !x -> x `B8.cons` escape x f `B8.snoc` x
+        Just !x -> (x `B8.cons` escape x f) `B8.snoc` x
         _ -> f
       escape c str = B8.intercalate (B8.pack [c,c]) $ B8.split c str
     in B.intercalate sep . map wrapField $ r


### PR DESCRIPTION
This fixes this error:

```
Configuring csv-conduit-0.3.0.2...
Building csv-conduit-0.3.0.2...
Preprocessing library csv-conduit-0.3.0.2...
[1 of 4] Compiling Data.CSV.Conduit.Types ( src/Data/CSV/Conduit/Types.hs, dist/build/Data/CSV/Conduit/Types.o )
[2 of 4] Compiling Data.CSV.Conduit.Parser.Text ( src/Data/CSV/Conduit/Parser/Text.hs, dist/build/Data/CSV/Conduit/Parser/Text.o )
[3 of 4] Compiling Data.CSV.Conduit.Parser.ByteString ( src/Data/CSV/Conduit/Parser/ByteString.hs, dist/build/Data/CSV/Conduit/Parser/ByteString.o )
[4 of 4] Compiling Data.CSV.Conduit ( src/Data/CSV/Conduit.hs, dist/build/Data/CSV/Conduit.o )

src/Data/CSV/Conduit.hs:121:20:
    Precedence parsing error
        cannot mix `B8.cons' [infixr 5] and `B8.snoc' [infixl 5] in the same infix expression
Failed to install csv-conduit-0.3.0.2
cabal: Error: some packages failed to install:
csv-conduit-0.3.0.2 failed during the building phase. The exception was:
ExitFailure 1
```

Tested with GHC 7.6.1
