### PR TITLE
Updated Data.CSV.Conduit to use the changed Data.Conduit api from versio...

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -1,5 +1,5 @@
 Name:                csv-conduit
-Version:             0.5.0
+Version:             0.6.0
 Synopsis:            A flexible, fast, conduit-based CSV parser library for Haskell.
 Homepage:            http://github.com/ozataman/csv-conduit
 License:             BSD3
@@ -74,7 +74,7 @@ library
     , attoparsec-conduit >= 0.5.0.2
     , base >= 4 && < 5
     , bytestring
-    , conduit == 0.5.*
+    , conduit >= 1.0 && < 2.0
     , containers >= 0.3
     , monad-control
     , text

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -54,8 +54,7 @@ test_simpleParse = do
 
 
 csvSettings :: CSVSettings
-csvSettings = defCSVSettings { csvQuoteChar = Just '`'
-                             , csvOutputQuoteChar = Just '`' }
+csvSettings = defCSVSettings { csvQuoteChar = Just '`'}
 
 testFile1, testFile2 :: FilePath
 testFile1 = "test/test.csv"


### PR DESCRIPTION
Updated Data.CSV.Conduit to use the changed Data.Conduit api from versions >1.0. Bumped version to 0.6 because of the change in dependencies, but the interface is actually unchanged.

This addresses issue #8.
