### PR TITLE
conduit 1.1 support

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -78,6 +78,7 @@ library
     , base >= 4 && < 5
     , bytestring
     , conduit >= 1.0 && < 2.0
+    , conduit-extra
     , containers >= 0.3
     , monad-control
     , text
@@ -90,6 +91,7 @@ library
     , mtl
     , mmorph
     , primitive
+    , resourcet
   ghc-prof-options: -fprof-auto
 
   if impl(ghc >= 7.2.1)

--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -36,6 +36,9 @@ import           Control.Monad.Morph
 import           Control.Monad.Primitive
 import           Control.Monad.ST
 import           Control.Monad.Trans
+import           Control.Monad.Trans.Resource       (MonadResource, MonadThrow,
+                                                     runExceptionT,
+                                                     runResourceT)
 import           Data.Attoparsec.Types              (Parser)
 import qualified Data.ByteString                    as B
 import           Data.ByteString.Char8              (ByteString)


### PR DESCRIPTION
Fully backwards compatible with conduit 1.0 as well.
