### PR TITLE
Fix dependency breakage

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -74,7 +74,6 @@ library
   hs-source-dirs: src
   build-depends:
       attoparsec >= 0.10
-    , attoparsec-conduit >= 0.5.0.2
     , base >= 4 && < 5
     , bytestring
     , conduit >= 1.0 && < 2.0
@@ -91,7 +90,7 @@ library
     , mtl
     , mmorph
     , primitive
-    , resourcet
+    , resourcet >= 1.1.2.1
   ghc-prof-options: -fprof-auto
 
   if impl(ghc >= 7.2.1)


### PR DESCRIPTION
- attoparsec-conduit has been deprecated, remove it
- resourcet 1.1.2 is broken, require a newer version
