### PR TITLE
Corrected Example 2 to work with myProcessor being a simple identity conduit

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ regressions or optimization opportunities.
     import Data.CSV.Conduit
     import Data.Text (Text)
 
-    myProcessor :: Conduit (Row Text) m (Row Text)
-    myProcessor = undefined
+    myProcessor :: Monad m => Conduit (Row Text) m (Row Text)
+    myProcessor = awaitForever $ yield
     
     -- Let's simply stream from a file, parse the CSV, reserialize it
     -- and push back into another file.


### PR DESCRIPTION
The example text indicates that myProcessor isn't trying to do anything, so replaced "undefined" with an implementation of a simple identity conduit.