### PR TITLE
Split classes, add explicit error handling

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -114,6 +114,7 @@ test-suite test
       base >= 4 && < 5
     , bytestring
     , containers >= 0.3
+    , conduit
     , csv-conduit
     , directory
     , vector

--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -228,13 +228,13 @@ intoCSVRow p = parse =$= puller
 
 
 -------------------------------------------------------------------------------
-instance (IntoCSV s (Row s'), Ord s', IsString s) => IntoCSV s (MapRow s') where
+instance (IntoCSV s (Row s'), Ord s') => IntoCSV s (MapRow s') where
     intoCSV set = intoCSVMap set
 
 
 -- | Generic 'MapRow' instance; any stream type with a 'Row' instance
 -- automatically gets a 'MapRow' instance.
-instance (FromCSV s (Row s'), Ord s', IsString s) => FromCSV s (MapRow s') where
+instance (FromCSV s (Row s'), IsString s) => FromCSV s (MapRow s') where
   rowToStr s r = rowToStr s . M.elems $ r
   fromCSV set = fromCSVMap set
 

--- a/src/Data/CSV/Conduit/Conversion.hs
+++ b/src/Data/CSV/Conduit/Conversion.hs
@@ -28,6 +28,7 @@ module Data.CSV.Conduit.Conversion
     -- * Type conversion
       Only(..)
     , Named (..)
+    , NamedE (..)
     , Record
     , NamedRecord
     , FromRecord(..)
@@ -112,10 +113,16 @@ type NamedRecord = M.Map B8.ByteString B8.ByteString
 -- | A wrapper around custom haskell types that can directly be
 -- converted/parsed from an incoming CSV stream.
 --
--- We define this wrapper to stop GHC from complaining
--- about overlapping instances. Just use 'getNamed' to get your
--- object out of the wrapper.
+-- We define this wrapper to stop GHC from complaining about
+-- overlapping instances. Just use 'getNamed' to get your object out
+-- of the wrapper. Note that this erases parse errors when you use it
+-- and is being kept for backwards-compatibility reasons. If you
+-- intend on handling parse errors, see 'NamedE'.
 newtype Named a = Named { getNamed :: a } deriving (Eq,Show,Read,Ord)
+
+-- | A wrapper just like 'Named' which, upon failing to parse the
+-- wrapped type captures the parse error.
+newtype NamedE a = NamedE { getNamedE :: Either String a } deriving (Eq,Show,Read,Ord)
 
 -- | A record corresponds to a single line in a CSV file.
 type Record = Vector B8.ByteString

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -94,11 +94,11 @@ newtype Foo = Foo { foo :: Bar } deriving (Show, Eq)
 
 
 instance FromNamedRecord Foo where
-  parseNamedRecord nr = Foo <$> nr .: "foo"
+  parseNamedRecord nr = fmap Foo (nr .: "foo")
 
 data Bar = Bar deriving (Show, Eq)
 
 
 instance FromField Bar where
-  parseField "bar" = pure Bar
+  parseField "bar" = return Bar
   parseField f     = fail ("Expected token \"bar\" but got \"" <> B.unpack f <> "\"")


### PR DESCRIPTION
This is for #24 

@ozataman @bitemyapp please weigh in. Relevant explanation from the commit log:

I decided to scrap the idea at least in this first attempt of
preserving the CSV class. It is really easy to upgrade and we would
definitely put this behind a breaking change. Once I got into the code
I realized keeping the CSV class would mean either:

1. Making it a superclass of both From/ToCSV and have it be completely
empty, which seems silly. Explicit instances people wrote for
CSV (admittedly rare, I'd think they'd piggyback on the existing ones)
would still break.
2. Using ConstraintKinds we could do type CSV s r = (FromCSV s r,
IntoCSV s r) but this would put a hard limit on supported GHC
versions (something I don't necessarily object to but it seems like a
trifling reason here) and would probably be kind of confusing to those
unfamiliar with that language feature. Plus I think the language
pragma would be viral, meaning they'd have to add it to files that had
CSV in the type signature if I'm not mistaken.

Thanks to the split, it allowed me to add a NamedE variant of Named
that does not erase parse errors and provide only the parsing instance
without having to provide a nonsensical serialization instance.