### PR TITLE
Update for new conduit, resourceT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ addons:
 # change flags or use --stack-yaml to point to a different file.
 matrix:
   include:
-    - env: ARGS="--resolver=lts-2"
-    - env: ARGS="--resolver=lts-3"
-    - env: ARGS="--resolver=lts-4"
-    - env: ARGS="--resolver=lts-5"
     - env: ARGS="--resolver=lts-6"
     - env: ARGS="--resolver=lts-7"
     - env: ARGS="--resolver=lts-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
     - env: ARGS="--resolver=lts-7"
     - env: ARGS="--resolver=lts-8"
     - env: ARGS="--resolver=lts-9"
+    - env: ARGS="--resolver=lts-10"
     - env: ARGS="--resolver=nightly"
   allow_failures:
     - env: ARGS="--resolver=nightly"
@@ -47,3 +48,4 @@ script:
 cache:
   directories:
   - $HOME/.stack
+  - .stack-work

--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -82,9 +82,10 @@ library
       attoparsec             >= 0.10
     , base                   >= 4 && < 5
     , bytestring
-    , conduit                >= 1.0 && < 2.0
+    , conduit                >= 1.2.8 && < 2.0
     , conduit-extra
     , containers             >= 0.3
+    , exceptions             >= 0.3
     , monad-control
     , text
     , data-default

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,10 @@
-resolver: lts-9.6
+resolver: lts-10.4
 packages:
 - .
-extra-deps: []
+extra-deps: # []
+- resourcet-1.2.0
+- conduit-1.3.0
+- conduit-extra-1.3.0
 flags:
   csv-conduit:
     lib-Werror: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,7 @@
 resolver: lts-10.4
 packages:
 - .
-extra-deps: # []
-- resourcet-1.2.0
-- conduit-1.3.0
-- conduit-extra-1.3.0
+extra-deps: []
 flags:
   csv-conduit:
     lib-Werror: true


### PR DESCRIPTION
This is for #32 

A few things here:
1. Several operators and type aliases in conduit that have been
provided for backwards compatibility are now actually deprecated. I've
updated our use of type aliases and operators to the recommended path.
2. Conduit has dropped the mmorph dependency which means the hoisting
we were doing wasn't working. They aliased ExceptionT to CatchT, a
monad transformer built for providing MonadThrow for pure code which
we need because the CSV machinery requires a MonadThrow
instance. CatchT was kind of limited so I handle it just in the CSV
parsing part, convert it to an either and then change the transformer
stack to ExceptT so it aborts the pipeline if it throws.

However, I think a lot of this is all hypothetical. Looking at the
code today, I cannot see a situation where the parsing can even throw
an exception. csv-conduit takes your parser, runs it in a non-throwing
manner and then eats rows. See #24 for some efforts of fixing that. So
I couldn't write a test that exercised this case but the types check
and non-exceptional decoding appears to work correctly.