### PR TITLE
Less aggressive quoting

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -96,7 +96,7 @@ library
     , mtl
     , mmorph
     , primitive
-    , resourcet              >= 1.1.2.1
+    , resourcet              >= 1.1.2.1 && < 1.2
 
   if impl(ghc >= 7.2.1)
     cpp-options: -DGENERICS


### PR DESCRIPTION
Currently csv-conduit outputs the string `""` for empty fields.  Postgres throws the following error when it encounters this for fields of type `double precision`:

    ERROR:  invalid input syntax for type double precision: ""

So while the current behavior is correct according to the spec, it seems to be less broadly supported in practice.  Also, if you're using csv-conduit to transform large files, the current behavior means that every single field will be quoted.  This means that you're outputting two additional bytes per field, making the resulting files noticeably larger than they need to be.

This PR only quotes fields if they contain the quote character, which is correct behavior according to the spec.