### PR TITLE
change documentation for named records

### DIFF
--- a/src/Data/CSV/Conduit/Conversion.hs
+++ b/src/Data/CSV/Conduit/Conversion.hs
@@ -347,7 +347,7 @@ instance (ToField a, U.Unbox a) => ToRecord (U.Vector a) where
 -- >
 -- > data Person = Person { name :: !Text, age :: !Int }
 -- >
--- > instance FromRecord Person where
+-- > instance FromNamedRecord Person where
 -- >     parseNamedRecord m = Person <$>
 -- >                          m .: "name" <*>
 -- >                          m .: "age"
@@ -368,7 +368,7 @@ class FromNamedRecord a where
 --
 -- > data Person = Person { name :: !Text, age :: !Int }
 -- >
--- > instance ToRecord Person where
+-- > instance ToNamedRecord Person where
 -- >     toNamedRecord (Person name age) = namedRecord [
 -- >         "name" .= name, "age" .= age]
 class ToNamedRecord a where


### PR DESCRIPTION
I changed the documentation to use `fromNamedRecord` and `toNamedRecord` in the instances that show how to use those typeclasses.