### PR TITLE
Add MonadFail instance for base >= 4.13

### DIFF
--- a/src/Data/CSV/Conduit/Conversion.hs
+++ b/src/Data/CSV/Conduit/Conversion.hs
@@ -751,6 +751,11 @@ instance Monad Parser where
     {-# INLINE (>>=) #-}
     return a = Parser $ \_kf ks -> ks a
     {-# INLINE return #-}
+
+#if MIN_VERSION_base(4,13,0)
+instance MonadFail Parser where
+#endif
+
     fail msg = Parser $ \kf _ks -> kf msg
     {-# INLINE fail #-}
 


### PR DESCRIPTION
This fixes the following errors:

```
.../csv-conduit-0.7.0.0/src/Data/CSV/Conduit/Conversion.hs:754:5: error:
    `fail' is not a (visible) method of class `Monad'
    |
754 |     fail msg = Parser $ \kf _ks -> kf msg
    |     ^^^^

.../csv-conduit-0.7.0.0/src/Data/CSV/Conduit/Conversion.hs:755:16: error:
    The INLINE pragma for `fail' lacks an accompanying binding
      (The INLINE pragma must be given where `fail' is declared)
    |
755 |     {-# INLINE fail #-}
    |                ^^^^
```