### PR TITLE
Update for Conduit >= 1.3

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -1,5 +1,5 @@
 Name:                csv-conduit
-Version:             0.7.1.0
+Version:             0.8
 Synopsis:            A flexible, fast, conduit-based CSV parser library for Haskell.
 Homepage:            http://github.com/ozataman/csv-conduit
 License:             BSD3
@@ -9,7 +9,7 @@ Maintainer:          Ozgun Ataman <ozataman@gmail.com>
 Category:            Data, Conduit, CSV, Text
 Build-type:          Simple
 Cabal-version:       >= 1.9.2
-Tested-with:         GHC == 7.6.1
+Tested-with:         GHC == 7.6.1, GHC == 8.6.5
 Description:
   CSV files are the de-facto standard in many situations involving data transfer,
   particularly when dealing with enterprise application or disparate database
@@ -82,13 +82,12 @@ library
       attoparsec             >= 0.10
     , base                   >= 4 && < 5
     , bytestring
-    , conduit                >= 1.2.8 && < 2.0
+    , conduit                >= 1.3.0 && < 2.0
     , conduit-extra
     , containers             >= 0.3
     , exceptions             >= 0.3
     , monad-control
     , text
-    , data-default
     , vector
     , array
     , blaze-builder

--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -129,13 +129,13 @@ class CSV s r where
   -----------------------------------------------------------------------------
   -- | Turn a stream of 's' into a stream of CSV row type. An example
   -- would be parsing a ByteString stream as rows of 'MapRow' 'Text'.
-  intoCSV :: (MonadThrow m) => CSVSettings -> ConduitM s r m ()
+  intoCSV :: (MonadThrow m) => CSVSettings -> ConduitT s r m ()
 
   -----------------------------------------------------------------------------
   -- | Turn a stream of CSV row type back into a stream of 's'. An
   -- example would be rendering a stream of 'Row' 'ByteString' rows as
   -- 'Text'.
-  fromCSV :: Monad m => CSVSettings -> ConduitM r s m ()
+  fromCSV :: Monad m => CSVSettings -> ConduitT r s m ()
 
 
 
@@ -202,13 +202,13 @@ instance (CSV s (Row s)) => CSV s (V.Vector s) where
 
 -------------------------------------------------------------------------------
 fromCSVRow :: (Monad m, IsString s, CSV s r)
-           => CSVSettings -> ConduitM r s m ()
+           => CSVSettings -> ConduitT r s m ()
 fromCSVRow set = awaitForever $ \row -> mapM_ yield [rowToStr set row, "\n"]
 
 
 
 -------------------------------------------------------------------------------
-intoCSVRow :: (MonadThrow m, AttoparsecInput i) => Parser i (Maybe o) -> ConduitM i o m ()
+intoCSVRow :: (MonadThrow m, AttoparsecInput i) => Parser i (Maybe o) -> ConduitT i o m ()
 intoCSVRow p = parse .| puller
   where
     parse = {-# SCC "conduitParser_p" #-} conduitParser p
@@ -227,7 +227,7 @@ instance (CSV s (Row s'), Ord s', IsString s) => CSV s (MapRow s') where
 
 -------------------------------------------------------------------------------
 intoCSVMap :: (Ord a, MonadThrow m, CSV s [a])
-           => CSVSettings -> ConduitM s (MapRow a) m ()
+           => CSVSettings -> ConduitT s (MapRow a) m ()
 intoCSVMap set = intoCSV set .| (headers >>= converter)
   where
     headers = do
@@ -257,7 +257,7 @@ instance (FromNamedRecord a, ToNamedRecord a, CSV s (MapRow ByteString)) =>
 
 -------------------------------------------------------------------------------
 fromCSVMap :: (Monad m, IsString s, CSV s [a])
-           => CSVSettings -> ConduitM (M.Map k a) s m ()
+           => CSVSettings -> ConduitT (M.Map k a) s m ()
 fromCSVMap set = awaitForever push
   where
     push r = mapM_ yield [rowToStr set (M.elems r), "\n"]
@@ -274,7 +274,7 @@ fromCSVMap set = awaitForever push
 writeHeaders
     :: (Monad m, CSV s (Row r), IsString s)
     => CSVSettings
-    -> ConduitM (MapRow r) s m ()
+    -> ConduitT (MapRow r) s m ()
 writeHeaders set = do
   mrow <- await
   case mrow of
@@ -320,14 +320,14 @@ decodeCSV
     -> Either SomeException (v a)
 decodeCSV set bs = runST $ runExceptT pipeline
   where
-    src :: ConduitM () s (ExceptT SomeException (ST s1)) ()
+    src :: ConduitT () s (ExceptT SomeException (ST s1)) ()
     src = C.sourceList [bs]
-    csvConvert :: ConduitM s a (ExceptT SomeException (ST s1)) ()
+    csvConvert :: ConduitT s a (ExceptT SomeException (ST s1)) ()
     csvConvert = transPipe (ExceptT . runCatchT) csvConvert'
-    csvConvert' :: ConduitM s a (CatchT (ST s1)) ()
+    csvConvert' :: ConduitT s a (CatchT (ST s1)) ()
     csvConvert' = intoCSV set
     growthFactor = 10
-    sink :: ConduitM a Void.Void (ExceptT SomeException (ST s1)) (v a)
+    sink :: ConduitT a Void.Void (ExceptT SomeException (ST s1)) (v a)
     sink = sinkVector growthFactor
     pipeline :: ExceptT SomeException (ST s1) (v a)
     pipeline = runConduit (src .| csvConvert .| sink)
@@ -387,11 +387,11 @@ transformCSV
     :: (MonadThrow m, CSV s a, CSV s' b)
     => CSVSettings
     -- ^ Settings to be used for both input and output
-    -> ConduitM () s m ()
+    -> ConduitT () s m ()
     -- ^ A raw stream data source. Ex: 'sourceFile inFile'
-    -> ConduitM a b m ()
+    -> ConduitT a b m ()
     -- ^ A transforming conduit
-    -> ConduitM s' Void.Void m ()
+    -> ConduitT s' Void.Void m ()
     -- ^ A raw stream data sink. Ex: 'sinkFile outFile'
     -> m ()
 transformCSV set = transformCSV' set set
@@ -415,11 +415,11 @@ transformCSV'
     -- ^ Settings to be used for input
     -> CSVSettings
     -- ^ Settings to be used for output
-    -> ConduitM () s m ()
+    -> ConduitT () s m ()
     -- ^ A raw stream data source. Ex: 'sourceFile inFile'
-    -> ConduitM a b m ()
+    -> ConduitT a b m ()
     -- ^ A transforming conduit
-    -> ConduitM s' Void.Void m ()
+    -> ConduitT s' Void.Void m ()
     -- ^ A raw stream data sink. Ex: 'sinkFile outFile'
     -> m ()
 transformCSV' setIn setOut source c sink = runConduit $
@@ -440,7 +440,7 @@ transformCSV' setIn setOut source c sink = runConduit $
 
 -------------------------------------------------------------------------------
 -- | An efficient sink that incrementally grows a vector from the input stream
-sinkVector :: (PrimMonad m, GV.Vector v a) => Int -> ConduitM a o m (v a)
+sinkVector :: (PrimMonad m, GV.Vector v a) => Int -> ConduitT a o m (v a)
 sinkVector by = do
     v <- lift $ GMV.new by
     go 0 v

--- a/src/Data/CSV/Conduit/Types.hs
+++ b/src/Data/CSV/Conduit/Types.hs
@@ -4,7 +4,6 @@
 module Data.CSV.Conduit.Types where
 
 -------------------------------------------------------------------------------
-import           Data.Default
 import qualified Data.Map     as M
 -------------------------------------------------------------------------------
 
@@ -37,10 +36,6 @@ defCSVSettings = CSVSettings
   { csvSep = ','
   , csvQuoteChar = Just '"'
   }
-
-
-instance Default CSVSettings where
-    def = defCSVSettings
 
 -------------------------------------------------------------------------------
 -- | A 'Row' is just a list of fields

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.4
+resolver: lts-14.27 # GHC 8.6.5
 packages:
 - .
 extra-deps: []


### PR DESCRIPTION
Smol upkeep PR

* use ConduitT instead of ConduitM (prettier type inference with newer conduit imports)
* tightened lower bound on conduit to 1.3.0 (which is where ConduitT was introduced)
* got rid of `data-default` dependency. Let's all get rid of data-default
* bump package version

BTW I'm super happy with this package, thanks all authors and contributors!