### PR TITLE
Compatibility with mtl-2.3.1

### DIFF
--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -39,8 +39,10 @@ import           Control.Exception
 import           Control.Monad.Catch.Pure           (CatchT)
 import           Control.Monad.Catch.Pure           (runCatchT)
 import           Control.Monad.Except
+import           Control.Monad.IO.Class             (MonadIO(liftIO))
 import           Control.Monad.Primitive
 import           Control.Monad.ST
+import           Control.Monad.Trans.Class          (MonadTrans(lift))
 import           Control.Monad.Trans.Resource       (MonadResource, MonadThrow,
                                                      runResourceT)
 import           Data.Attoparsec.Types              (Parser)


### PR DESCRIPTION
Tested using the following `cabal.project`:

```
packages: .

source-repository-package
  type: git
  location: git@github.com:haskell/mtl.git
  tag: 9c91d2afee42c8e96321a7aaf39148069025a69a
```

Tested using `cabal build --constraint='transformers>=0.6' -w ghc-9.4.2`

In contrast to #46, this only makes the minimal changes necessary.