### PR TITLE
add many stack resolvers to CI

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -4,29 +4,34 @@ on:
   - pull_request
 
 jobs:
-  build:
-      name: Build and Test
-      runs-on: ubuntu-latest
-      steps:
-        - name: Clone project
-          uses: actions/checkout@v4
+  linux:
+    name: ${{ matrix.resolver }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        resolver:
+          - "lts-22.20"
+          - "lts-21.25"
+          - "lts-20.26"
+          - "lts-19.33"
+          - "lts-18.28"
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v4
 
-        - name: Cache dependencies
-          uses: actions/cache@v4
-          with:
-            path: ~/.stack
-            key: ${{ runner.os }} - stack - ${{ hashFiles('stack.yaml') }}
-            restore-keys: ${{ runner.os }}-
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.resolver }}
 
-        - name: Setup GHC
-          run: |
-            stack --version
-            stack setup
-
-        - name: Build sources
-          run: |
-            stack build
-
-        - name: Run tests
-          run: |
-            stack test
+      - name: Build and run tests
+        shell: bash
+        run: |
+          set -ex
+          stack --version
+          stack test --fast --no-terminal --resolver ${{ matrix.resolver }}


### PR DESCRIPTION
Somehow I didn't merge it before. Just as we test many **GHC** versions in **cabal**, we can do it with **stack** resolvers. Easy peasy.