### PR TITLE
Change misleading documentation for `decodeCSV`

### DIFF
--- a/src/Data/CSV/Conduit.hs
+++ b/src/Data/CSV/Conduit.hs
@@ -369,7 +369,7 @@ readCSVFile set fp = liftIO . runResourceT $ runConduit $ sourceFile fp .| intoC
 --
 -- For example for 'ByteString':
 --
--- >>> s <- LB.readFile "my.csv"
+-- >>> s <- B.readFile "my.csv"
 -- >>> decodeCSV defCSVSettings s :: Either SomeException (Vector (Vector ByteString))
 --
 -- will work as long as the data is comma separated.


### PR DESCRIPTION
The `LB.readFile` makes it seem like you should use a lazy `ByteString`, but the `CSV` class only has instances for strict `ByteString`s.