### PR TITLE
Fix parsing of DOS line endings

### DIFF
--- a/csv-conduit.cabal
+++ b/csv-conduit.cabal
@@ -58,6 +58,7 @@ extra-source-files:
   changelog.md
   README.md
   test/test-mac-excel.csv
+  test/test-windows-excel.csv
   test/test.csv
   test/Test.hs
   test/test.xls

--- a/src/Data/CSV/Conduit/Parser/ByteString.hs
+++ b/src/Data/CSV/Conduit/Parser/ByteString.hs
@@ -59,7 +59,7 @@ row :: CSVSettings -> Parser (Maybe (Row ByteString))
 row csvs = csvrow csvs <|> badrow
 
 csvEndOfLine :: Parser ()
-csvEndOfLine = (word8 10 >> return ()) <|> (word8 13 >> return ())
+csvEndOfLine = (word8 10 >> return ()) <|> ((word8 13 *> word8 10) >> return ()) <|> (word8 13 >> return ())
 
 badrow :: Parser (Maybe (Row ByteString))
 badrow = P.takeWhile (not . C8.isEndOfLine) *>

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -34,6 +34,7 @@ baseTests =
   [ testCase "mapping with id works" test_identityMap,
     testCase "simple parsing works" (test_simpleParse testFile1),
     testCase "simple parsing works for Mac-Excel" (test_simpleParse testFile3),
+    testCase "simple parsing works for Windows-Excel" (test_simpleParse testFile4),
     testCase "fails parsing gracefully" test_parseFail,
     testCase "OrderedMap" test_orderedMap
   ]
@@ -125,10 +126,11 @@ test_orderedMap = do
 csvSettings :: CSVSettings
 csvSettings = defCSVSettings {csvQuoteCharAndStyle = Just ('`', DontQuoteEmpty)}
 
-testFile1, testFile2, testFile3 :: FilePath
+testFile1, testFile2, testFile3, testFile4 :: FilePath
 testFile1 = "test/test.csv"
 testFile2 = "test/test.csv"
 testFile3 = "test/test-mac-excel.csv"
+testFile4 = "test/test-windows-excel.csv"
 
 testXLS :: FilePath
 testXLS = "test/test.xls"

--- a/test/test-windows-excel.csv
+++ b/test/test-windows-excel.csv
@@ -1,0 +1,4 @@
+Col1,Col2,Col3,Sum
+A,2,3,5
+B,3,4,7
+"Field using the quote char ""this is the in-quoted value""",4,5,9


### PR DESCRIPTION
The ByteString parser only recognized Unix (\n) and Mac (\r) line endings, but not DOS/Windows (\r\n). This PR fixes that. Note that the Text parser already worked fine in all three cases.

Cheers,
Martin